### PR TITLE
CADC-9347: add session type logos to list

### DIFF
--- a/src/main/webapp/css/science-portal.css
+++ b/src/main/webapp/css/science-portal.css
@@ -229,8 +229,8 @@
   text-align: center!important;
   font-size: 24px;
   margin: 5px;
-  width: 130px;
-  height: 70px;
+  width: 100px;
+  height: 85px;
 }
 
 /* nav link title - not part of link */
@@ -246,10 +246,12 @@
   border-style: outset;
   border-width: thin;
   overflow: hidden;
+  width: 100px;
+  height: 85px;
 }
 
 /* nav link title (below icon */
-.sp-session-link-name {
+.sp-session-link-type {
   text-align: center!important;
   font-size: 14px;
   font-weight: bold;
@@ -271,6 +273,16 @@ button.sp-session-delete {
   border: none;
   backgound-color: #e7e7e7;
   font-size: 10;
+}
+
+.sp-icon-desktop {
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.sp-icon-img {
+  width: 40px;
+  height: 40px;
 }
 
 

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -33,6 +33,7 @@
     var portalCore = new cadc.web.science.portal.core.PortalCore(inputs)
     var portalSessions = new cadc.web.science.portal.session.PortalSession(inputs)
     var _selfPortalApp = this
+    this.baseURL = inputs.baseURL
 
     // ------------ Page load functions ------------
 
@@ -59,6 +60,7 @@
         // consider saving current session in a hidden value so it's only done
         // when needed.
         loadSoftwareStackImages($(this).val())
+        setSessionName($(this).val())
       })
 
       // This element is on the info modal
@@ -170,7 +172,7 @@
         var $titleDiv = $('<div />')
         var $titleItem = $('<div />')
         $titleItem.prop('class', 'sp-session-type')
-        $titleItem.html(this.type)
+        $titleItem.html(this.name)
         $titleDiv.append($titleItem)
 
         var $deleteButton = $('<button/>')
@@ -192,21 +194,30 @@
         $anchorItem.attr('data-name', this.name)
         $anchorItem.prop('class', 'sp-session-connect')
 
-        var $iconItem = $('<i />')
+        var $iconItem
 
         var iconClass
         if (this.type === 'notebook') {
-          iconClass = 'fas fa-cube'
+          $iconItem = $('<img />')
+          $iconItem.prop('src', _selfPortalApp.baseURL + '/science-portal/images/jupyterLogo.jpg')
+          //$iconItem.prop('width', 50)
+          //$iconItem.prop('height', 50)
+          iconClass = 'sp-icon-img'
         } else if (this.type === 'desktop') {
-          iconClass = 'fas fa-desktop'
+          $iconItem = $('<i />')
+          iconClass = 'fas fa-desktop sp-icon-desktop'
         } else if (this.type === 'carta') {
-          iconClass = 'fas fa-cube'
+          $iconItem = $('<img />')
+          $iconItem.prop('src', _selfPortalApp.baseURL + '/science-portal/images/cartaLogo.png')
+          //$iconItem.prop('width', 40)
+          //$iconItem.prop('height', 40)
+          iconClass = 'sp-icon-img'
         }
         $iconItem.prop('class', iconClass)
 
         var $nameItem = $('<div />')
-        $nameItem.prop('class', 'sp-session-link-name')
-        $nameItem.html(this.name)
+        $nameItem.prop('class', 'sp-session-link-type')
+        $nameItem.html(this.type)
 
         $anchorItem.append($iconItem)
         $anchorItem.append($nameItem)
@@ -217,6 +228,17 @@
       $sessionListDiv.append($unorderedList)
       $('.sp-session-connect').on('click', handleConnectRequest)
       $('.sp-session-delete').on('click', handleDeleteSession)
+    }
+
+    /**
+     * This function provides a default session name that integrates
+     * the number of sessions of that type. Name can be overridden by user
+     * in the launch form.
+     * @param sessionType
+     */
+    function setSessionName(sessionType) {
+      var sessionName = portalSessions.getDefaultSessionName(sessionType)
+      $('#sp_session_name').val(sessionName)
     }
 
     function populateSelect(selectID, optionData, placeholderText, defaultOptionID) {
@@ -341,8 +363,8 @@
           portalCore.hideInfoModal(true)
           portalCore.trigger(_selfPortalApp, cadc.web.science.portal.events.onSessionRequestOK, sessionInfo)
         })
-        .catch(function(message) {
-          portalCore.handleAjaxError(message)
+        .catch(function(request) {
+          portalCore.handleAjaxError(request)
         })
     }
 
@@ -359,7 +381,7 @@
               // this request. Use the name & type posted in form
               // to identify this request going forward
               resolve({"name": sessionData.get("name"), "type": sessionData.get("type")})
-            } else {
+            } else if (request.status === 400) {
               reject(request)
             }
           },
@@ -415,7 +437,8 @@
         populateSelect('sp_session_type', tempTypeList, 'select type',_sessionTypeMap.default)
 
         // notebook is default
-        loadSoftwareStackImages("notebook")
+        loadSoftwareStackImages('notebook')
+        setSessionName('notebook')
       })
     }
 

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -200,8 +200,6 @@
         if (this.type === 'notebook') {
           $iconItem = $('<img />')
           $iconItem.prop('src', _selfPortalApp.baseURL + '/science-portal/images/jupyterLogo.jpg')
-          //$iconItem.prop('width', 50)
-          //$iconItem.prop('height', 50)
           iconClass = 'sp-icon-img'
         } else if (this.type === 'desktop') {
           $iconItem = $('<i />')
@@ -209,8 +207,6 @@
         } else if (this.type === 'carta') {
           $iconItem = $('<img />')
           $iconItem.prop('src', _selfPortalApp.baseURL + '/science-portal/images/cartaLogo.png')
-          //$iconItem.prop('width', 40)
-          //$iconItem.prop('height', 40)
           iconClass = 'sp-icon-img'
         }
         $iconItem.prop('class', iconClass)

--- a/src/main/webapp/js/science_portal_core.js
+++ b/src/main/webapp/js/science_portal_core.js
@@ -228,6 +228,12 @@
           displayText = 'You are not authorised to use Skaha resources. Contact CANFAR admin' +
           ' for information on how to get set up with a resource allocation and permission to access the service.'
           break
+        case 400:
+          // Do as good a test for max number of sessions reached message from Skaha as possible:
+          if (request.responseText.includes('session already running')) {
+            displayText = 'Limit of number of sessions of selected type reached'
+            break
+          }
         default:
           displayText = request.responseText
           break

--- a/src/main/webapp/js/science_portal_session.js
+++ b/src/main/webapp/js/science_portal_session.js
@@ -41,7 +41,6 @@
       _selfPortalSess._sessionList = {}
     }
 
-
     function getSessionList() {
       if (_selfPortalSess._sessionList === {}) {
         initSessionList()
@@ -89,6 +88,10 @@
       return isStatus
     }
 
+    function isRunningSession(session) {
+      return isSessionStatus(session, 'Running')
+    }
+
     function isSessionStatus(session, sessionStatus) {
       var isStatus = false
       if (session.status == sessionStatus) {
@@ -96,6 +99,24 @@
       }
       return isStatus
     }
+
+    /**
+     * Build a default session name based on the session type and current count
+     * of sessions
+     * @param sessionType
+     * @returns {*}
+     */
+    function getDefaultSessionName(sessionType) {
+      // First entry will have a '1'
+      var count = 1
+      for (var i = 0; i < _selfPortalSess._sessionList.length; i++) {
+        if (_selfPortalSess._sessionList[i].type === sessionType) {
+          count++
+        }
+      }
+      return sessionType + count
+    }
+
 
 
     function setSessionList(sessionList) {
@@ -284,12 +305,14 @@
       $.extend(this, {
         setServiceURLs: setServiceURLs,
         initSessionList: initSessionList,
+        getDefaultSessionName: getDefaultSessionName,
         getSessionByID: getSessionByID,
         getSessionByNameType: getSessionByNameType,
         getSessionList: getSessionList,
         loadSessionList: loadSessionList,
         setSessionList: setSessionList,
         isSessionStatus: isSessionStatus,
+        isRunningSession: isRunningSession,
         isSessionStatusByID: isSessionStatusByID,
         isSessionListEmpty : isSessionListEmpty,
         pollSessionRunning: pollSessionRunning,

--- a/src/main/webapp/json/contexthelp_en.json
+++ b/src/main/webapp/json/contexthelp_en.json
@@ -10,7 +10,7 @@
     "title": "Software Stack"
   },
   "session_name": {
-    "tipHTML": "Name for the session. Alphanumeric characters.",
+    "tipHTML": "Name for the session. Default name reflects the current number of sessions of the selected type. Alphanumeric characters only.",
     "placement": "top",
     "title": "Session Name"
   },


### PR DESCRIPTION
- adding jupyter & carta logos to the session list elements
- swap location of session name and type in the display (more similar to jupyterLab display, so perhaps easier to use.)
- adding a default session name that reflects the number of sessions of a given type
- upgrade message from skaha on attempting to open too many sessions of a given type (base message is too generic for a user to act on)
- small code tweaks to make it more comprehensible (changing 'message' to 'request' as that's the kind of object it is.)