### PR TITLE
CADC-9348: integrating feedback from demo

### DIFF
--- a/src/main/webapp/css/science-portal.css
+++ b/src/main/webapp/css/science-portal.css
@@ -228,13 +228,13 @@
 .sp-session-link {
   text-align: center!important;
   font-size: 24px;
-  margin: 5px;
+  margin-right: 5px;
   width: 100px;
-  height: 85px;
+  height: 95px;
 }
 
 /* nav link title - not part of link */
-.sp-session-type {
+.sp-session-name {
   text-align: left;
   font-size: 14px;
   font-weight: bold;
@@ -242,12 +242,7 @@
 
 /* nav link box */
 .sp-session-connect {
-  border: green;
-  border-style: outset;
-  border-width: thin;
   overflow: hidden;
-  width: 100px;
-  height: 85px;
 }
 
 /* nav link title (below icon */
@@ -284,5 +279,42 @@ button.sp-session-delete {
   width: 40px;
   height: 40px;
 }
+
+/* Used for controlling accessibility of session list items */
+.sp-link-container {
+  width: 100px;
+  height: 75px;
+  position: relative;
+}
+
+.sp-link-disable,
+.sp-link-connect {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.sp-link-disable {
+  z-index: 10;
+  background-color: lightgray;
+  opacity: 50%;
+  padding-top: 60px;
+  font-size: 12px;
+  font-weight: bold;
+  text-align: right;
+  font-style: italic;
+}
+
+.sp-session-anchor {
+  border-style: groove;
+  border-color: aliceblue;
+  border-width: thin;
+}
+
+
+
+
 
 

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -97,7 +97,7 @@
         portalCore.setProgressBar("okay")
         portalCore.hideInfoModal(true)
 
-        if ( _selfPortalApp.isPolling == false) {
+        if ( _selfPortalApp.isPolling === false) {
           // Flag polling is occurring so only one instance is running at a time.
           // Any changes in session list will be picked up by the single polling instance
           _selfPortalApp.isPolling == true
@@ -111,7 +111,7 @@
               }
             })
             .catch(function (message) {
-              portalCore.setInfoModal('Error getting session lise',
+              portalCore.setInfoModal('Error getting session list',
                 'Unable to get session list. ' +
                 'Reload the page to try again, or contact CANFAR admin for assistance.', true, false, false)
             })

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -115,7 +115,18 @@
         showLaunchForm(false)
 
         // Start polling for session start before
-        portalSessions.pollSessionRunning(sessionData, 10000, 200)
+        //portalSessions.pollSessionRunning(sessionData, 10000, 200)
+        //  .then( function(runningSession) {
+        //    // Grab new session list
+        //    checkForSessions()
+        //  })
+        //  .catch(function (message) {
+        //    portalCore.setInfoModal('Error checking for sessions',
+        //      'Unable to get session list. ' +
+        //      'Reload the page to try again, or contact CANFAR admin for assistance.', true, false, false)
+        //  })
+
+        portalSessions.pollSessionList(200)
           .then( function(runningSession) {
             // Grab new session list
             checkForSessions()
@@ -125,6 +136,9 @@
               'Unable to get session list. ' +
               'Reload the page to try again, or contact CANFAR admin for assistance.', true, false, false)
           })
+
+
+
       })
 
       portalCore.subscribe(portalSessions, cadc.web.science.portal.session.events.onSessionDeleteOK, function (e, sessionID) {
@@ -169,23 +183,51 @@
         var $listItem = $('<li />')
         $listItem.prop('class', 'sp-session-link')
 
+        // $itemContainer holds both the linkItem with the
+        // connect and delete controls, sesion type logo, etc.,
+        // and potentially a 'blockingDiv' that puts a panel
+        // over the linkItem, blocking access when the session
+        // isn't Running.
+        var $itemContainer = $('<div />')
+        $itemContainer.prop('class', 'sp-link-container')
+
+        if (this.status != 'Running') {
+          // Add the extra blocking div
+          var $blockingDiv = $('<div />')
+          $blockingDiv.prop('class', 'sp-link-disable')
+          $itemContainer.append($blockingDiv)
+          $blockingDiv.html(this.status)
+        }
+
+        // Create the main $linkItem div to hold session
+        // information and action controls
+        var $linkItem = $('<div />')
+        $linkItem.prop('class', 'sp-link-connect')
+
         var $titleDiv = $('<div />')
+        $titleDiv.prop('class', 'sp-session-title')
         var $titleItem = $('<div />')
-        $titleItem.prop('class', 'sp-session-type')
+        $titleItem.prop('class', 'sp-session-name')
         $titleItem.html(this.name)
         $titleDiv.append($titleItem)
 
         var $deleteButton = $('<button/>')
-        // needed to issue delete sanely
+        // add session data to delete button so it can be
+        // sent on click to the delete handler
         $deleteButton.attr('data-id', this.id)
         $deleteButton.attr('data-name', this.name)
         $deleteButton.prop("class", "fas fa-times sp-session-delete")
         $titleItem.append($deleteButton)
 
+        //TODO: this would be better moved up so it's attached roughly
+        // in the order it shows up.
         $listItem.append($titleDiv)
 
+        var $anchorDiv = $('<div />')
+        $anchorDiv.prop('class', 'sp-session-anchor')
         var $anchorItem = $('<a />')
-        $anchorItem.prop('href', '#')
+        $anchorItem.prop('href', '')
+        $anchorDiv.append($anchorItem)
 
         // Attach session data to the anchor element
         $anchorItem.attr('data-connecturl', this.connectURL)
@@ -224,7 +266,10 @@
 
         $anchorItem.append($iconItem)
         $anchorItem.append($nameItem)
-        $listItem.append($anchorItem)
+
+        $linkItem.append($anchorDiv)
+        $itemContainer.append($linkItem)
+        $listItem.append($itemContainer)
         $unorderedList.append($listItem)
       })
 

--- a/src/main/webapp/launch/index.jsp
+++ b/src/main/webapp/launch/index.jsp
@@ -78,7 +78,7 @@
                   <div id="sp_list_progress_bar"></div>
 
                   <%-- Body of session list will be built in this div  --%>
-                  <div class="panel-body science-portal-panel-body" id="sp_session_list">
+                  <div class="panel-body sp-panel-body" id="sp_session_list">
                   </div>
                 <div class="sp-button-bar">
                   <%-- session action button bar --%>
@@ -168,7 +168,7 @@
                             </select>
                           </div>
                         </div>
-                        
+
                         <div class="form-group sp-form-memory">
                           <label for="sp_memory"
                                  class="col-sm-3 control-label"


### PR DESCRIPTION
- session list prohibits connecting to anything other than 'Running' session.
- session list allows deleting 'Succeeded' sessions
- session list displays session status if not 'Running'
- polling is simplified, so it only occurs when session list is grabbed, continuing until all listed sessions are in a 'stable' state: either Running or Succeeded. 'Stable' means a state that only changes if the session owner does something specific (or Skaha service dies somehow.)
