### PR TITLE
CADC-9648: change layout to gracefully handle long names...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 sourceCompatibility = '1.8'
 group = 'ca.nrc.cadc'
-version = '1001'
+version = '1002'
 
 ext {
     intTest_user_name = 'CADCtest'

--- a/src/main/webapp/css/science-portal.css
+++ b/src/main/webapp/css/science-portal.css
@@ -18,9 +18,9 @@
   border-color: #ccc;
 }
 
-.sp-panel-body {
-  padding: 5px;
-}
+/*.sp-panel-body {*/
+/*  padding: 5px;*/
+/*}*/
 
 .sp-progress-bar {
   width: 100%;
@@ -31,7 +31,6 @@
   height: 8px;
   /*background-image: linear-gradient(to bottom, #ffffff 0, #ffffff 100%);*/
   margin-bottom: 0px;
-
 }
 
 .form-group {
@@ -232,17 +231,20 @@
   text-align: center!important;
   font-size: 24px;
   margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin-bottom: 15px;
   width: 100px;
-  height: 95px;
 }
 
 /* nav link title - not part of link */
 .sp-session-name {
-  text-align: left;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: bold;
+  overflow: hidden;
+}
+
+.sp-session-panel-body {
+  padding-left: 10;
+  padding-bottom: 0;
 }
 
 /* nav link box */
@@ -253,8 +255,9 @@
 /* nav link title (below icon */
 .sp-session-link-type {
   text-align: center!important;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: bold;
+  font-style: italic;
 }
 
 .sp-button-bar {
@@ -272,10 +275,11 @@ button.sp-session-delete {
   float:right;
   font-size: 10px;
   backgound-color: #e7e7e7;
-  margin-top: 3px;
+  margin-top: -1px;
   border: darkgray;
   border-style: solid;
   border-width: thin;
+  -webkit-border-radius: 5px;
 }
 
 .sp-icon-desktop {
@@ -284,19 +288,22 @@ button.sp-session-delete {
 }
 
 .sp-icon-img {
-  width: 40px;
-  height: 40px;
+  width: 50px;
+  height: 50px;
 }
 
 /* Used for controlling accessibility of session list items */
 .sp-link-container {
   width: 100px;
-  height: 75px;
+  height: 90px;
   position: relative;
+  border-style: groove;
+  border-color: aliceblue;
+  -webkit-border-radius: 5px;
 }
 
 .sp-link-disable,
-.sp-link-connect {
+.sp-session-ctl {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -304,21 +311,25 @@ button.sp-session-delete {
   left: 0;
 }
 
+.sp-session-ctl {
+  height: 14px;
+  -webkit-border-radius: 5px;
+  margin-right: 1px;
+  z-index: 50; /* always on top */
+}
+
 .sp-link-disable {
   z-index: 10;
   background-color: lightgray;
   opacity: 50%;
-  padding-top: 60px;
   font-size: 12px;
   font-weight: bold;
-  text-align: right;
+  text-align: left;
   font-style: italic;
 }
 
 .sp-session-anchor {
-  border-style: groove;
-  border-color: aliceblue;
-  border-width: thin;
+  padding-top: 15px;
 }
 
 .sp-close {

--- a/src/main/webapp/css/science-portal.css
+++ b/src/main/webapp/css/science-portal.css
@@ -18,10 +18,6 @@
   border-color: #ccc;
 }
 
-/*.sp-panel-body {*/
-/*  padding: 5px;*/
-/*}*/
-
 .sp-progress-bar {
   width: 100%;
   height: 8px;

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -78,7 +78,7 @@
                   <div id="sp_list_progress_bar"></div>
 
                   <%-- Body of session list will be built in this div  --%>
-                  <div class="panel-body sp-panel-body" id="sp_session_list">
+                  <div class="panel-body sp-panel-body sp-session-panel-body" id="sp_session_list">
                     <ul class="nav nav-pills">
 
                       <li role="presentation" class="sp-session-link sp-session-add">
@@ -135,7 +135,7 @@
                           <div class="col-sm-6">
                             <input type="text" class="form-control sp-form sp-form-input"
                                    id="sp_session_name" name="name"
-                                   placeholder="provide session name" tabindex="1" required/>
+                                   placeholder="provide session name" tabindex="1" required maxlength="15"/>
                           </div>
                         </div>  <!-- end form group -->
 

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -210,7 +210,6 @@
           // Create the main $linkItem div to hold session
           // information and action controls
           var $linkItem = $('<div />')
-          $linkItem.prop('class', 'sp-link-connect')
 
           if (this.status != 'Running') {
             // Add the blocking div

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -198,24 +198,20 @@
           var $listItem = $('<li />')
           $listItem.prop('class', 'sp-session-link')
 
-
-          // $itemContainer holds both the linkItem with the
-          // connect and delete controls, session type logo, etc.,
-          // and potentially a 'blockingDiv' that puts a panel
+          // $itemContainer holds: both the
+          // - linkItem with the connect affordance (session type & logo)
+          // - delete affordance
+          // - potentially a 'blockingDiv' that puts a panel
           // over the linkItem, blocking access when the session
           // isn't Running.
           var $itemContainer = $('<div />')
           $itemContainer.prop('class', 'sp-link-container')
 
-          // Create the main $linkItem div to hold session
-          // information and action controls
-          var $linkItem = $('<div />')
-
           if (this.status != 'Running') {
             // Add the blocking div
             var $blockingDiv = $('<div />')
             $blockingDiv.prop('class', 'sp-link-disable')
-            $linkItem.append($blockingDiv)
+            $itemContainer.append($blockingDiv)
             $blockingDiv.html(this.status)
           }
 
@@ -232,8 +228,7 @@
           $deleteButton.attr('data-toggle', 'tooltip')
           $deleteButton.attr('title', 'delete session')
           $buttonDiv.append($deleteButton)
-          $linkItem.append($buttonDiv)
-
+          $itemContainer.append($buttonDiv)
 
           var $anchorDiv = $('<div />')
           $anchorDiv.prop('class', 'sp-session-anchor')
@@ -250,7 +245,6 @@
           $anchorItem.prop('class', 'sp-session-connect')
 
           var $iconItem
-
           var iconClass
           // TODO: this is the only place that session types
           // are hard coded. Consider expanding sessiontype_map_en.json to include
@@ -280,8 +274,7 @@
           $anchorItem.append($iconItem)
           $anchorItem.append($nameItem)
 
-          $linkItem.append($anchorDiv)
-          $itemContainer.append($linkItem)
+          $itemContainer.append($anchorDiv)
           $listItem.append($itemContainer)
 
           // Add session name to bottom of control

--- a/src/main/webapp/js/science_portal.js
+++ b/src/main/webapp/js/science_portal.js
@@ -112,7 +112,7 @@
           _selfPortalApp.isPolling == true
 
           // If everything is stable, stop. If no, kick off polling
-          portalSessions.pollSessionList(1000)
+          portalSessions.pollSessionList(8000)
             .then(function (finalState) {
               if (finalState == 'done') {
                 // Grab new session list
@@ -200,32 +200,29 @@
 
 
           // $itemContainer holds both the linkItem with the
-          // connect and delete controls, sesion type logo, etc.,
+          // connect and delete controls, session type logo, etc.,
           // and potentially a 'blockingDiv' that puts a panel
           // over the linkItem, blocking access when the session
           // isn't Running.
           var $itemContainer = $('<div />')
           $itemContainer.prop('class', 'sp-link-container')
 
-          if (this.status != 'Running') {
-            // Add the extra blocking div
-            var $blockingDiv = $('<div />')
-            $blockingDiv.prop('class', 'sp-link-disable')
-            $itemContainer.append($blockingDiv)
-            $blockingDiv.html(this.status)
-          }
-
           // Create the main $linkItem div to hold session
           // information and action controls
           var $linkItem = $('<div />')
           $linkItem.prop('class', 'sp-link-connect')
 
-          var $titleDiv = $('<div />')
-          $titleDiv.prop('class', 'sp-session-title')
-          var $titleItem = $('<div />')
-          $titleItem.prop('class', 'sp-session-name sp-b-tooltip')
-          $titleItem.html(this.name)
-          $titleDiv.append($titleItem)
+          if (this.status != 'Running') {
+            // Add the blocking div
+            var $blockingDiv = $('<div />')
+            $blockingDiv.prop('class', 'sp-link-disable')
+            $linkItem.append($blockingDiv)
+            $blockingDiv.html(this.status)
+          }
+
+          // delete button
+          var $buttonDiv = $('<div />')
+          $buttonDiv.prop('class', 'sp-session-ctl sp-b-tooltip')
 
           var $deleteButton = $('<button/>')
           // add session data to delete button so it can be
@@ -235,12 +232,13 @@
           $deleteButton.prop('class', 'fas fa-times sp-session-delete')
           $deleteButton.attr('data-toggle', 'tooltip')
           $deleteButton.attr('title', 'delete session')
-          $titleItem.append($deleteButton)
+          $buttonDiv.append($deleteButton)
+          $linkItem.append($buttonDiv)
 
-          $listItem.append($titleDiv)
 
           var $anchorDiv = $('<div />')
           $anchorDiv.prop('class', 'sp-session-anchor')
+
           var $anchorItem = $('<a />')
           $anchorItem.prop('href', '')
           $anchorDiv.append($anchorItem)
@@ -286,8 +284,14 @@
           $linkItem.append($anchorDiv)
           $itemContainer.append($linkItem)
           $listItem.append($itemContainer)
-          $unorderedList.append($listItem)
 
+          // Add session name to bottom of control
+          var $titleItem = $('<div />')
+          $titleItem.prop('class', 'sp-session-name')
+          $titleItem.html(this.name)
+          $listItem.append($titleItem)
+
+          $unorderedList.append($listItem)
         })
         $sessionListDiv.append($unorderedList)
         $('.sp-session-connect').on('click', handleConnectRequest)
@@ -295,10 +299,7 @@
 
         // add tooltips
         $('[data-toggle="tooltip"]').tooltip()
-
       }
-
-
     }
 
     /**


### PR DESCRIPTION
... and not cover delete, add or reload controls. Limit session name length to 15 on input. (Chris W requested this part as well.) 