### PR TITLE
CADC-11882: remove image host from name

### DIFF
--- a/public/dev/js/science_portal.js
+++ b/public/dev/js/science_portal.js
@@ -114,6 +114,8 @@
         portalSessions.setServiceURLs(portalCore.sessionServiceURLs)
         portalForm.setServiceURLs(portalCore.sessionServiceURLs)
 
+        portalForm.setDataFilters(portalCore.dataFilters)
+
         // Get portalForm to start collecting form data
         portalForm.getFormData()
 
@@ -257,12 +259,12 @@
             "name" : this.name,
             "status": this.status,
             "logo": iconSrc,
-            "image": this.image,
+            "image": portalCore.dataFilters.imageName(this.image),
             "RAM": "2G",
             "cores": "2",
             "altText": iconLabel,
             "connectURL": this.connectURL,
-            "startTime": portalSessions.getDisplayStartTime(this),
+            "startTime": portalCore.dataFilters.startTime(this.startTime),
             "type" : this.type,
             "deleteHandler": handleDeleteSession,
             "connectHandler": handleConnectRequest
@@ -370,7 +372,6 @@
       portalCore.setModal(_reactApp, "Requesting Session", "Requesting new session", true, false, false)
       Promise.resolve(postSessionRequestAjax(portalCore.sessionServiceURLs.session, _prunedFormData))
         .then(function(sessionInfo) {
-          //portalCore.setProgressBar("okay")
           portalCore.setPageState("success", false, _reactApp)
           portalCore.hideModal(_reactApp)
           portalCore.trigger(_selfPortalApp, cadc.web.science.portal.events.onSessionRequestOK, sessionInfo)

--- a/public/dev/js/science_portal_core.js
+++ b/public/dev/js/science_portal_core.js
@@ -54,8 +54,6 @@
       })
     }
 
-    //var redirectUtil = new ca.nrc.cadc.RedirectUtil()
-
     var portalLogin = new cadc.web.science.portal.login.PortalLogin(inputs)
     this.userManager = new cadc.web.UserManager(inputs)
 
@@ -155,10 +153,6 @@
       setPageState("success", false, reactAppLink)
     }
 
-    function setProgressBar(state) {
-      var a = "TODO"
-    }
-
     // Communicate AJAX progress and status using progress bar
     function setPageState(barType, isAnimated, reactAppLink, alertMsg) {
       var pageState = {
@@ -196,6 +190,38 @@
     function handleAjaxError(request, reactAppLink) {
       hideModal(reactAppLink)
       setAjaxFail(request, reactAppLink)
+    }
+
+    // ----------- Data Filtering and Display Functions -----------------
+
+    function getDisplayStartTime(startTime) {
+      // v 3.0: Times come from skaha in UTC, with 'T' and 'Z'
+      var tmpTime = ""
+      if (startTime !== undefined) {
+        tmpTime = startTime.replace("T", " ")
+        tmpTime = tmpTime.replace("Z", "")
+      } else {
+        tmpTime = "not available"
+      }
+      return tmpTime
+    }
+
+    function getDisplayImageName(imageName) {
+      // v 3.0: each image has the host name of the
+      // harbor instance as it's first element. For now,
+      // this is pruned off as it's the same for all images
+      // served by the portal
+      var firstSlashIdx = imageName.indexOf("/")
+      var prunedImage = imageName.substr(firstSlashIdx + 1, imageName.length)
+      return prunedImage
+    }
+
+    // Structure is used to pass into science_portal_form to produce the image list for display,
+    // also used in science_portal to set data to be passed into SessionItem react component.
+    // values are the functions immediately above this declaration
+    this.dataFilters = {
+      "startTime" : getDisplayStartTime,
+      "imageName" : getDisplayImageName
     }
 
     // ---------- Event Handling Functions ----------
@@ -410,7 +436,6 @@
       setAjaxSuccess: setAjaxSuccess,
       setAjaxFail: setAjaxFail,
       handleAjaxError: handleAjaxError,
-      setProgressBar: setProgressBar,
       setPageState: setPageState,
       setReactAppRef: setReactAppRef,
       clearAjaxAlert: clearAjaxAlert,

--- a/public/dev/js/science_portal_form.js
+++ b/public/dev/js/science_portal_form.js
@@ -45,11 +45,17 @@
 
     // Values in this object will come from PortalCore
     this.sessionURLs = {}
+    this.dataFilters = {}
 
     function setServiceURLs(URLObject) {
       // More than one endpoint is pulled from URLObject
       // so store entire thing
       _selfPortalForm.sessionURLs = URLObject
+    }
+
+    function setDataFilters(filterObject) {
+      // Raw data from skaha endpoint needs to be filtered
+      _selfPortalForm.dataFilters = filterObject
     }
 
     function setContentBase(contentBase) {
@@ -143,7 +149,7 @@
           for (var j=0; j<_selfPortalForm._sessionTypeList.length; j++) {
             _selfPortalForm._imageData[_selfPortalForm._sessionTypeList[j]] = {
               "imageList": new Array(),
-              "imageIDList": new Array()
+              "imageDisplayList": new Array()
             }
           }
 
@@ -152,7 +158,11 @@
             if (isTypeInList(curImage.type)) {
               // add into the imageList structure
               _selfPortalForm._imageData[curImage.type].imageList.push(curImage)
-              _selfPortalForm._imageData[curImage.type].imageIDList.push(curImage.id)
+              var imageData = {
+                "id": curImage.id,
+                "name" : _selfPortalForm.dataFilters.imageName(curImage.id)
+              }
+              _selfPortalForm._imageData[curImage.type].imageDisplayList.push(imageData)
             }
             // else skip is it's not a type currently supported in the UI for
             // launching sessions.
@@ -173,7 +183,7 @@
       // return what it's asking for, in an array of IDs.
       var imageList = null
       if (typeof _selfPortalForm._imageData[sessionType] !== "undefined") {
-        return _selfPortalForm._imageData[sessionType].imageIDList
+        return _selfPortalForm._imageData[sessionType].imageDisplayList
       } else {
         return imageList
       }
@@ -335,6 +345,7 @@
         interruptAjaxProcessing: interruptAjaxProcessing,
         loadSessionTypeMap: loadSessionTypeMap,
         setContentBase: setContentBase,
+        setDataFilters: setDataFilters,
         setServiceURLs: setServiceURLs,
         isTypeInList: isTypeInList
       })

--- a/public/dev/js/science_portal_form.js
+++ b/public/dev/js/science_portal_form.js
@@ -158,9 +158,15 @@
             if (isTypeInList(curImage.type)) {
               // add into the imageList structure
               _selfPortalForm._imageData[curImage.type].imageList.push(curImage)
+
+              var imageName = curImage.id
+              // Filter if possible
+              if (typeof _selfPortalForm.dataFilters.imageName !== undefined) {
+                imageName = _selfPortalForm.dataFilters.imageName(curImage.id)
+              }
               var imageData = {
                 "id": curImage.id,
-                "name" : _selfPortalForm.dataFilters.imageName(curImage.id)
+                "name" : imageName
               }
               _selfPortalForm._imageData[curImage.type].imageDisplayList.push(imageData)
             }

--- a/public/dev/js/science_portal_session.js
+++ b/public/dev/js/science_portal_session.js
@@ -30,7 +30,7 @@
   function PortalSession() {
     var _selfPortalSess = this
     var _isEmpty = true
-    this._sessionList = {}
+    this._sessionList = []
     this._sessionTypeList = []
 
     function setServiceURLs(URLObject) {
@@ -247,7 +247,7 @@
         _selfPortalSess._sessionList = sessionList
         _selfPortalSess._isEmpty = false
       } else {
-        _selfPortalSess._sessionList = {}
+        _selfPortalSess._sessionList = []
         _selfPortalSess._isEmpty = true
       }
     }
@@ -363,20 +363,6 @@
         return new Promise(checkCondition)
     }
 
-    // ---------- Session metadata conversion functions ----------
-
-    function getDisplayStartTime(sessionItem) {
-      // Times come from skaha in UTC, with 'T' and 'Z'
-      var tmpTime = sessionItem.startTime
-      if (tmpTime !== undefined) {
-        tmpTime = tmpTime.replace("T", " ")
-        tmpTime = tmpTime.replace("Z", "")
-      } else {
-        tmpTime = "not available"
-      }
-      return tmpTime
-    }
-
     // ---------- Event Handling Functions ----------
 
     function subscribe(target, event, eHandler) {
@@ -398,7 +384,6 @@
         setServiceURLs: setServiceURLs,
         initSessionLists: initSessionLists,
         getDefaultSessionName: getDefaultSessionName,
-        getDisplayStartTime: getDisplayStartTime,
         getSessionByID: getSessionByID,
         getSessionByNameType: getSessionByNameType,
         getSessionList: getSessionList,

--- a/src/react/SciencePortalForm.js
+++ b/src/react/SciencePortalForm.js
@@ -150,7 +150,7 @@ class SciencePortalForm extends React.Component {
                     className="sp-form-cursor"
                     >
                     {this.state.fData.imageList.map(mapObj => (
-                      <option className="sp-form" key={mapObj} value={mapObj}>{mapObj}</option>
+                      <option className="sp-form" key={mapObj.id} value={mapObj.id}>{mapObj.name}</option>
                     ))}
                   </Form.Select>
                 </Col>


### PR DESCRIPTION
Will remove redundant 'image.canfar.net/' from the beginning of each image name displayed to the UI. NOTE: host name is retained in the raw data to be used in session requests.

Affects session item card display and images dropdown in launch form. 

- centralized functions to filter data for display to UI into science_portal_core.js
- created image list ready with display name, to push into react app to display in SciencePortalForm component
- used newly located function to get data ready to put into SessionItem react component (no change to component)
- removed unneeded & commented out code for progress bar (technical debt fix)

Keeping version of app the same as it hasn't been released to production yet.