### PR TITLE
Add memory usage statistic.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,6 +110,7 @@ const PLATFORM_USAGE_TEST = {
   },
   "instances" : {},
   "cpu" : {},
+  "ram" : {},
   "listType": "loading"
 }
 

--- a/src/main/java/org/opencadc/scienceportal/ApplicationConfiguration.java
+++ b/src/main/java/org/opencadc/scienceportal/ApplicationConfiguration.java
@@ -3,7 +3,7 @@ package org.opencadc.scienceportal;
 
 import ca.nrc.cadc.util.StringUtil;
 
-import java.net.URI;
+import java.util.Date;
 
 import org.apache.commons.configuration2.CombinedConfiguration;
 import org.apache.commons.configuration2.Configuration;
@@ -17,6 +17,9 @@ import org.apache.log4j.Logger;
 
 
 public class ApplicationConfiguration {
+
+    public static final long BUILD_TIME_MS = new Date().getTime();
+
     private static final Logger LOGGER = Logger.getLogger(ApplicationConfiguration.class);
 
     public static final String DEFAULT_CONFIG_FILE_PATH = System.getProperty("user.home")

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -19,7 +19,7 @@
 <%-- Used to prevent JavaScript caching. --%>
 <jsp:useBean id="current" class="java.util.Date" />
 <c:set var="contextPath" value="${pageContext.request.contextPath}" />
-<c:set var="currTimestampMS" value="${current.time}" />
+<c:set var="buildVersion" value="<%= ApplicationConfiguration.BUILD_TIME_MS %>" scope="application" />
 
 <!DOCTYPE html>
 <html lang="en">
@@ -75,12 +75,12 @@
     </div>
 
     <%--local files ot pick up--%>
-    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_login.js?v=${currTimestampMS}"></script>
-    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_core.js?v=${currTimestampMS}"></script>
-    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_session.js?v=${currTimestampMS}"></script>
-    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_form.js?v=${currTimestampMS}"></script>
-    <script type="application/javascript" src="${contextPath}/dist/js/science_portal.js?v=${currTimestampMS}"></script>
-    <script type="application/javascript" src="${contextPath}/dist_config/sp_dist_config.js?v=${currTimestampMS}"></script>
+    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_login.js?v=${buildVersion}"></script>
+    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_core.js?v=${buildVersion}"></script>
+    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_session.js?v=${buildVersion}"></script>
+    <script type="application/javascript" src="${contextPath}/dist/js/science_portal_form.js?v=${buildVersion}"></script>
+    <script type="application/javascript" src="${contextPath}/dist/js/science_portal.js?v=${buildVersion}"></script>
+    <script type="application/javascript" src="${contextPath}/dist_config/sp_dist_config.js?v=${buildVersion}"></script>
 
     <script type="application/javascript">
       window.runStartupTasks = () => {
@@ -99,7 +99,7 @@
 
     <%-- render the react app last - App.js's render cycle will call
       window.runStartupTasks() on completion. --%>
-    <script src="${contextPath}/dist/react-app.js?v=${currTimestampMS}"></script>
+    <script src="${contextPath}/dist/react-app.js?v=${buildVersion}"></script>
 
   </body>
 </html>

--- a/src/react/SciencePortalPlatformLoad.js
+++ b/src/react/SciencePortalPlatformLoad.js
@@ -88,6 +88,24 @@ function SciencePortalPlatformLoad(props) {
         }
       ]
     }
+
+    var yAxisRAMData = {
+      labels: ["Memory usage"],
+      datasets: [
+        {
+          label: "used",
+          data: [props.usage.ram.used],
+          backgroundColor: "#F19F18",
+          hoverBackgroundColor: "#4F97A3"
+        },
+        {
+          label: "free",
+          data: [props.usage.ram.free],
+          backgroundColor: "#dedede",
+          hoverBackgroundColor: "#efefef"
+        }
+      ]
+    }
   }
 
   // Hanging on to this code in case user feedback in the first pass is to
@@ -154,6 +172,36 @@ function SciencePortalPlatformLoad(props) {
     barThickness: barThickness
   }
 
+  var horizontalStackedRAMOptions = {
+    indexAxis: "y",
+    maintainAspectRatio: false,
+    plugins: {
+      title: {
+        display: false,
+      }
+    },
+    responsive: true,
+    scales: {
+      x: {
+        stacked: true,
+        grid: {
+          display: false,
+        },
+        max: props.usage.ram.total
+      },
+      y: {
+        beginAtZero: true,
+        stacked: true,
+        grid: {
+          display: false,
+        },
+        max: 50
+      },
+    },
+    borderRadius: 4,
+    barThickness: barThickness
+  }
+
   var horizontalStackedBarOptions = {
     indexAxis: "y",
     maintainAspectRatio: false,
@@ -169,7 +217,7 @@ function SciencePortalPlatformLoad(props) {
         grid: {
           display: false,
         },
-        max: props.usage.instances.total
+        max: Math.max(props.usage.instances.total, 10)
       },
       y: {
         beginAtZero: true,
@@ -199,6 +247,16 @@ function SciencePortalPlatformLoad(props) {
             </Col>
           </Row>
           <Row className="sp-usage-bar-row">
+            <Col sm={12}>
+              <div className="sp-usage-ram-title">
+                Available RAM:  {props.usage.ram.free}{props.usage.ram.unit} / {props.usage.ram.total}{props.usage.ram.unit}
+              </div>
+              <div className="sp-usage-bar">
+                <Bar options={horizontalStackedRAMOptions} data={yAxisRAMData} />
+              </div>
+            </Col>
+          </Row>
+          <Row className="sp-usage-bar-row">
             <Col>
               <div className="sp-usage-session-title">
                 Running Instances: {props.usage.instances.total}
@@ -220,6 +278,20 @@ function SciencePortalPlatformLoad(props) {
 
       {props.usage.listType === "loading" &&
         <>
+          <Row className="sp-usage-title-placeholder">
+          <Col>
+            <Placeholder className="sp-form-p sp-usage-title-placeholder"  animation="glow">
+              <Placeholder className="sp-form-placeholder sp-usage-title-placeholder" xs={12} />
+            </Placeholder>
+          </Col>
+          </Row>
+          <Row className="sp-usage-placeholder">
+            <Col>
+              <Placeholder className="sp-form-p sp-usage-placeholder"  animation="glow">
+                <Placeholder className="sp-form-placeholder sp-usage-placeholder" xs={12} />
+              </Placeholder>
+            </Col>
+          </Row>
           <Row className="sp-usage-title-placeholder">
           <Col>
             <Placeholder className="sp-form-p sp-usage-title-placeholder"  animation="glow">

--- a/src/react/SciencePortalPlatformLoad.js
+++ b/src/react/SciencePortalPlatformLoad.js
@@ -96,7 +96,7 @@ function SciencePortalPlatformLoad(props) {
           label: "used",
           data: [props.usage.ram.used],
           backgroundColor: "#F19F18",
-          hoverBackgroundColor: "#4F97A3"
+          hoverBackgroundColor: "#D28B15"
         },
         {
           label: "free",

--- a/src/react/sp-session-list.css
+++ b/src/react/sp-session-list.css
@@ -105,7 +105,7 @@ div.sp-usage-updated-row {
   margin-top: -45px;
 }
 
-div.sp-usage-cpu-title {
+div.sp-usage-ram-title, div.sp-usage-cpu-title {
   margin-bottom: -20px;
   font-weight: bold;
   font-size: 13px;


### PR DESCRIPTION
JSON from Skaha service includes quantified size strings for memory usage (e.g. "4.0G" rather than 4.0), so parse that and use to display statistics.