### PR TITLE
fix: use type interactive

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,6 +5,6 @@
 # tags with and without build number so operators use the versioned
 # tag but we always keep a timestamped tag in case a semantic tag gets
 # replaced accidentally
-VER=1.0.0
+VER=1.0.1
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/public/dev/js/science_portal_session.js
+++ b/public/dev/js/science_portal_session.js
@@ -387,7 +387,7 @@
     }
 
     function loadSessionList() {
-      Promise.resolve(_getAjaxData(_selfPortalSess.sessionServiceURL, {}))
+      Promise.resolve(_getAjaxData(`${_selfPortalSess.sessionServiceURL}?type=interactive`, {}))
         .then(function(sessionList) {
           setSessionList(sessionList)
           trigger(_selfPortalSess, cadc.web.science.portal.session.events.onLoadSessionListDone)
@@ -504,7 +504,7 @@
         interval = interval || 200
 
         var checkCondition = function (resolve, reject) {
-          _getAjaxData(_selfPortalSess.sessionServiceURL)
+          _getAjaxData(`${_selfPortalSess.sessionServiceURL}?type=interactive`)
             .then(function (sessionList) {
               _selfPortalSess.setSessionList(sessionList)
               if (_selfPortalSess.isAllSessionsStable()) {


### PR DESCRIPTION
# Description
Minimize sessions returned by filtering interactive ones only

# Changes
- Use `type=interactive` query for sessions